### PR TITLE
Clippy and fmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: |
+        rustup component add rust-clippy
+        cargo build --verbose
     - name: Lint
       run: cargo clippy -- -D warnings
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,5 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+    - name: Lint
+      run: cargo clippy -- -D warnings
     - name: Run tests
       run: cargo test --verbose

--- a/src/body.rs
+++ b/src/body.rs
@@ -162,18 +162,7 @@ pub fn body(v: &Value, document_function_name: &str) -> String {
     command::DEF_P_CMD.to_string(),
     command::DEF_PN_CMD.to_string(),
   ];
-  let value_str = vec_to_str(&def_value_vec);
-  value_str
-}
-
-fn vec_to_str(v: &Vec<String>) -> String {
-  let len = v.len();
-  let mut s = String::new();
-  for i in 0..len {
-    let st = format!("{}", v[i]);
-    s.push_str(&st)
-  }
-  s
+  def_value_vec.concat()
 }
 
 pub fn default_json() -> Value {
@@ -253,7 +242,7 @@ pub fn make_command_vec(v: &Value) -> Vec<String> {
 }
 
 pub fn json_vec_to_str_vec(
-  j_vec: &Vec<Value>,
+  j_vec: &[Value],
   default: Option<&str>,
   default_vec: Option<&Vec<&str>>,
 ) -> Vec<String> {
@@ -262,15 +251,14 @@ pub fn json_vec_to_str_vec(
   for i in 0..len {
     let v = &j_vec[i];
     let s_op = v.as_str();
-    match s_op {
-      None => match default {
-        None => match default_vec {
-          None => {}
-          Some(ve) => s_vec.push(format!("{}", ve[i])),
-        },
-        Some(s) => s_vec.push(format!("{}", s)),
-      },
-      Some(s) => s_vec.push(format!("{}", s)),
+    if let Some(s) = s_op {
+      s_vec.push(s.to_owned());
+    }
+    else if let Some(s) = default {
+      s_vec.push(s.to_owned())
+    }
+    else if let Some(ve) = default_vec {
+      s_vec.push(ve[i].to_owned())
     }
   }
   s_vec

--- a/src/body/doc.rs
+++ b/src/body/doc.rs
@@ -98,17 +98,7 @@ pub fn make_document_function(
     OUTLINE.to_string(),
     DOC.to_string(),
   ];
-  let main_str = vec_to_str(&v);
+  let main_str = v.concat();
 
   format!("let {} config bt ={}", function_name, main_str)
-}
-
-fn vec_to_str(v: &Vec<String>) -> String {
-  let len = v.len();
-  let mut s = String::new();
-  for i in 0..len {
-    let st = format!("{}", v[i]);
-    s.push_str(&st)
-  }
-  s
 }

--- a/src/body/font.rs
+++ b/src/body/font.rs
@@ -53,9 +53,8 @@ pub fn set_font_data(font_data_opt: &&Option<&Vec<Value>>) -> String {
   };
   let font_vec = set_font_vec(&font_data);
   let mut s = String::new();
-  let vec_len = font_vec.len();
-  for i in 0..vec_len {
-    let (tag, name, ratio, correction) = &font_vec[i];
+  for font in font_vec {
+    let (tag, name, ratio, correction) = &font;
     let st = match name {
       None => String::new(),
       Some(n) => format!(
@@ -68,7 +67,7 @@ pub fn set_font_data(font_data_opt: &&Option<&Vec<Value>>) -> String {
   s
 }
 
-fn set_font_vec(font_data: &Vec<Value>) -> Vec<(String, Option<String>, String, String)> {
+fn set_font_vec(font_data: &[Value]) -> Vec<(String, Option<String>, String, String)> {
   let mut stack = vec![];
   let mut data_vec = vec![];
   for j in font_data.iter() {

--- a/src/body/sec.rs
+++ b/src/body/sec.rs
@@ -9,12 +9,12 @@ pub fn default_sec_fun_name() -> Vec<&'static str> {
   vec!["section", "subsection", "subsubsection"]
 }
 
-fn set_sec_fun_vec(depth: usize, sec_fun_list: &Vec<String>) -> Vec<String> {
+fn set_sec_fun_vec(depth: usize, sec_fun_list: &[String]) -> Vec<String> {
   let mut stack = vec![];
   let len = sec_fun_list.len();
   for i in 1..(depth + 1) {
     let s = if i <= len {
-      format!("{}", &sec_fun_list[(i - 1)])
+      sec_fun_list[(i - 1)].clone()
     } else {
       format!("sec{}", i)
     };
@@ -35,7 +35,7 @@ fn make_sec_num_ref(sec_depth: &u64) -> String {
 fn add_toc_lst(i: usize, toc_depth_64: &u64) -> String {
   let toc_depth = *toc_depth_64 as usize;
   if i > toc_depth {
-    format!("()")
+    "()".to_owned()
   } else {
     format!(
       "toc-lst-ref <- (Sec{}(label, title, lst)) :: !toc-lst-ref",
@@ -64,7 +64,6 @@ fn make_num_lst(n: usize) -> String {
 }
 
 fn make_sec_bb_fun() -> String {
-  format!(
     "
 let make-sec-bb ctx label count-lst i title outline-lst outline-title-opt main =
   let sec-ctx =
@@ -112,11 +111,10 @@ let make-sec-bb ctx label count-lst i title outline-lst outline-title-opt main =
   in
   let bb-inner = read-block ctx main in
     bb-title +++ bb-inner
-  \n"
-  )
+  \n".to_owned()
 }
 
-fn make_sec_cmd(sec_fun_name: &Vec<String>, sec_fun: &str, depth: &u64, toc_depth: &u64) -> String {
+fn make_sec_cmd(sec_fun_name: &[String], sec_fun: &str, depth: &u64, toc_depth: &u64) -> String {
   let mut main_str = String::new();
   let len = sec_fun_name.len();
   for i in 1..(len + 1) {

--- a/src/body/sec.rs
+++ b/src/body/sec.rs
@@ -24,12 +24,10 @@ fn set_sec_fun_vec(depth: usize, sec_fun_list: &[String]) -> Vec<String> {
 }
 
 fn make_sec_num_ref(sec_depth: &u64) -> String {
-  let mut main_str = String::new();
-  for i in 1..(sec_depth + 1) {
-    let s = format!("let-mutable sec{}-count <- 0\n", i);
-    main_str.push_str(&s)
-  }
-  main_str
+  (1..sec_depth+1)
+    .map(|i| format!("let-mutable sec{}-count <- 0\n", i))
+    .collect::<Vec<String>>()
+    .concat()
 }
 
 fn add_toc_lst(i: usize, toc_depth_64: &u64) -> String {
@@ -55,11 +53,9 @@ fn make_cout(n: usize, depth_64: &u64) -> String {
 }
 
 fn make_num_lst(n: usize) -> String {
-  let mut main_str = String::new();
-  for i in 1..(n + 1) {
-    let s = format!("!sec{}-count; ", i);
-    main_str.push_str(&s)
-  }
+  let main_str = (1..n+1)
+    .map(|i| format!("!sec{}-count; ", i))
+    .collect::<Vec<String>>().concat();
   format!("[{}]", main_str)
 }
 
@@ -167,15 +163,12 @@ pub fn make_sec_str(
 
 pub fn command_vec(sec_depth: &u64, sec_fun_list: Vec<String>) -> Vec<String> {
   let sec_vec = set_sec_fun_vec(*sec_depth as usize, &sec_fun_list);
-  let mut stack = vec![];
-  for v in sec_vec.iter() {
-    let s = format!(
-      "direct +{} : [string?; inline-text?; inline-text; block-text] block-cmd",
-      v
-    );
-    stack.push(s)
-  }
-  stack
+  sec_vec
+      .into_iter()
+      .map(|v| format!(
+        "direct +{} : [string?; inline-text?; inline-text; block-text] block-cmd", v
+      ))
+      .collect()
 }
 
 #[test]

--- a/src/body/toc.rs
+++ b/src/body/toc.rs
@@ -16,7 +16,6 @@ fn make_toc_type(depth: u64) -> String {
 }
 
 fn make_bb_fun() -> String {
-  format!(
     "
 let make-dots-line ctx w =
   let-rec sub n ib =
@@ -99,12 +98,10 @@ let make-toc-bb ctx text-width label count-lst i title =
         |> ib-link-to-location-frame label
       in
       let main-bb = line-break true true toc-ctx main-ib in
-        main-bb +++ block-skip 5pt\n"
-  )
+        main-bb +++ block-skip 5pt\n".to_owned()
 }
 
 fn make_title_fun() -> String {
-  format!(
     "
 let make-toc-title-bb ctx main-bb =
   let title-ctx =
@@ -116,8 +113,7 @@ let make-toc-title-bb ctx main-bb =
   let title-ib = read-inline title-ctx {{目次}} ++ inline-fil in
   let title-bb = line-break true false title-ctx title-ib in
     title-bb +++ block-skip 5pt +++ main-bb
-  "
-  )
+  ".to_owned()
 }
 
 fn make_toc_fun(depth: u64, fun_name: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ pub mod default;
 pub mod module;
 pub mod package;
 
-fn write_file(file_name: String, text: String) -> () {
+fn write_file(file_name: String, text: String) {
   let mut file = File::create(file_name).unwrap();
   file.write_all(text.as_bytes()).unwrap();
 }
@@ -55,17 +55,17 @@ fn main() {
 
   if let Some(output) = matches.value_of("output") {
     output_name = Some(output.to_string());
-    print!("Value for output: {}\n", output);
+    println!("Value for output: {}", output);
   }
 
   if let Some(config) = matches.value_of("config") {
     config_name = Some(config.to_string());
-    print!("Value for config: {}\n", config);
+    println!("Value for config: {}", config);
   }
 
   if let Some(default) = matches.value_of("default") {
     default_name = Some(default.to_string());
-    print!("Output for default: {}\n", default);
+    println!("Output for default: {}", default);
   }
 
   let package_data = vec!["annot".to_string(), "list".to_string(), "math".to_string()];

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,11 +109,10 @@ fn main() {
     body::default_json(),
   );
 
-  let _ = match default_name {
-    None => {}
-    Some(s) => write_file(
+  if let Some(s) = default_name {
+    write_file(
       s,
       serde_json::to_string_pretty(&default_json).unwrap_or_default(),
-    ),
+    )
   };
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -24,20 +24,18 @@ pub fn package(default: Vec<String>, require: Vec<String>, import: Vec<String>) 
 }
 
 fn make_require(v: Vec<String>) -> String {
-  let len = v.len();
   let mut st = String::new();
-  for i in 0..len {
-    let s = format!("@require: {}\n", v[i]);
+  for v_elem in v {
+    let s = format!("@require: {}\n", v_elem);
     st.push_str(&s)
   }
   st
 }
 
 fn make_import(v: Vec<String>) -> String {
-  let len = v.len();
   let mut st = String::new();
-  for i in 0..len {
-    let s = format!("@import: {}\n", v[i]);
+  for v_elem in v {
+    let s = format!("@import: {}\n", v_elem);
     st.push_str(&s)
   }
   st


### PR DESCRIPTION
How about using [clippy](https://github.com/rust-lang/rust-clippy) for linting?This PR introduces [clippy](https://github.com/rust-lang/rust-clippy) and fixes warnings that [clippy](https://github.com/rust-lang/rust-clippy) detects.
If you don't mind changing indent shift size, I can add another commit that formats your codes with rustfmt and checks whether the codes surely formatted by github workflows.